### PR TITLE
Fix: SE-0054 related warnings

### DIFF
--- a/RoundCoachMark/RoundCoachMark/CoachMarker.swift
+++ b/RoundCoachMark/RoundCoachMark/CoachMarker.swift
@@ -112,7 +112,7 @@ public class CoachMarker
     }
     static public func unregisterMark(_ handler:CoachMarkHandler)
     {
-        NotificationCenter.default.removeObserver(handler.token)
+        NotificationCenter.default.removeObserver(handler.token!)
     }
     
 // MARK: - MARKS DIRECT REGISTRATION INTERFACE
@@ -296,7 +296,7 @@ public class CoachMarker
         // Automatic un-registration staticaly registered marks, which handlers are not stored externally
         handlers.forEach 
         { handler in
-            NotificationCenter.default.removeObserver(handler.token)
+            NotificationCenter.default.removeObserver(handler.token!)
         }
         handlers.removeAll()
         if (marksContainer?.gestureRecognizers?.count ?? 0) > 0 
@@ -405,7 +405,7 @@ public class CoachMarkHandler
     deinit
     {
         print("MarkControlHandler deinit: \(self)")
-        NotificationCenter.default.removeObserver(token)
+        NotificationCenter.default.removeObserver(token!)
     }
 }
 


### PR DESCRIPTION
SE-0054: https://github.com/apple/swift-evolution/blob/master/proposals/0054-abolish-iuo.md

Fixed the `Coercion of implicitly unwrappable value of type 'NSObjectProtocol?' to 'Any' does not unwrap optional` warnings.

**Since the `token` field of `CoachMarkHandler` is marked as non-optional we can safely forcibly unwrap it wherever it's used.**

The warning appears in XCode 11 because, as stated in SE-0054, `!` is treated differently now in regards to IUO values.

Specifically:`...the appearance of ! at the end of a property or variable declaration's type no longer indicates that the declaration has IUO type; rather, it indicates that (1) the declaration has optional type, and (2) the declaration has an attribute indicating that its value may be implicitly forced. ...`

Hence even though `var token:NSObjectProtocol!` is declared with `!`, XCode will still prefer to bind it to an optional since `NotificationCenter.default.removeObserver(...)` accept `Any` value that can be `nil`. Hence, the annoying warning.