### PR TITLE
Expanded the list of supported Swift versions in podsec

### DIFF
--- a/RoundCoachMark.podspec
+++ b/RoundCoachMark.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary      = "Useful tools for round coachmarks"
   s.homepage     = "https://github.com/digital-horizon/RoundCoachMark"
   s.license      = 'MIT'
-  s.swift_versions = '4.2'
+  s.swift_versions = ['4.2', '5.0', '5.1', '5.2']
 
   s.author       = { 
     "Dima Choock" => "d.choock@gmail.com" 

--- a/RoundCoachMark/1.0.4/RoundCoachMark.podspec
+++ b/RoundCoachMark/1.0.4/RoundCoachMark.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary      = "Useful tools for round coachmarks"
   s.homepage     = "https://github.com/digital-horizon/RoundCoachMark"
   s.license      = 'MIT'
-  s.swift_versions = '4.2'
+  s.swift_versions = ['4.2', '5.0', '5.1', '5.2']
 
   s.author       = { 
     "Dima Choock" => "d.choock@gmail.com" 


### PR DESCRIPTION
The project was tested to be compatible with the following versions of Swift: 4.2, 5.0, 5.1, 5.2.
Added these to the podsec in order to avoid warnings when the pod is imported in a Swift 5+ project.

Cocoapods supports multiple versions of Swift to be specified in podsec: [Swift Version Variants
](https://blog.cocoapods.org/CocoaPods-1.9.0-beta/). If it's not done, and a project importing the pod using Swift version above the currently specified 4.2, that results in Warnings and XCode nagging to "Conver to Swift 5".  Specifying all of the supported versions in the podsec solves the issue.